### PR TITLE
Misc fixes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 # set default command line options
-addopts = -v -s --log-level=debug
+addopts = -v -s --log-level=debug --log-cli-level=debug
 
 # register our known markers
 markers =

--- a/selftests/test_hardware.py
+++ b/selftests/test_hardware.py
@@ -1,0 +1,56 @@
+import pytest
+
+import optest
+from optest import system
+from optest.system import BaseSystem
+from optest.console import FileConsole
+from optest.petitboot import PetitbootHelper
+
+import misc
+
+@pytest.fixture(params=["qemu", "smc", "fsp"])
+def system(request):
+    config = misc.get_config(request.param)
+    sys = config.create_system()
+
+    # FIXME: test prep step?
+    sys.get_console().connect()
+
+    yield sys
+
+    sys.poweroff()
+    config.cleanup()
+
+def test_os_boot(system):
+    if not system.has_state('os'):
+        raise pytest.skip("System doesn't support the os state")
+
+    if not system.host.username():
+        raise pytest.skip("No os login details")
+
+    c = system.get_console()
+
+    system.poweroff()
+    system.boot_to('os')
+
+    os_uname = c.run_command('uname -a')
+
+    assert "openpower" not in os_uname
+
+def test_off_on_off_on(system):
+    c = system.get_console()
+
+    system.poweroff()
+    system.boot_to('petitboot')
+    PetitbootHelper(c).goto_shell()
+    out1 = c.run_command('uname -a')
+
+    system.poweroff()
+    system.boot_to('petitboot')
+    PetitbootHelper(c).goto_shell()
+    out2 = c.run_command('uname -a')
+
+    assert out1 == out2
+
+def test_bmc_is_alive(system):
+    assert system.bmc_is_alive() == True

--- a/src/optest/console.py
+++ b/src/optest/console.py
@@ -303,7 +303,11 @@ class Console():
             raises ValueError if you try to run sudo
             raises CommandFailed if the command fails
             might also raise ConsoleDisconnect if the underlying console
-            object disconnects'''
+            object disconnects
+
+            Returns a (list, int) tuple. The list contains each line of
+            console output from the command and the int is the exit code.
+        '''
 
         if command.strip().startswith('sudo '):
             raise ValueError('use .sudo_bash() to elevate the shell rather than sudo directly')
@@ -361,6 +365,10 @@ class Console():
         return res, echo_rc
 
     def run_command(self, command, timeout=60, retries=0):
+        ''' Same as try_command(), but with an optional retry mechanism.
+            Commands are retried when try_command() throws an exception. If the
+            number of re-tries are exceeded we re-throw the exception.
+        '''
         counter = 0
         while counter <= retries:
             try:

--- a/src/optest/console.py
+++ b/src/optest/console.py
@@ -419,6 +419,11 @@ class FileConsole(Console):
         # file.
         self.pty = opexpect.spawn("cat {}".format(inputfile), logfile=self.logfile)
 
+    def is_connected(self):
+        if self.state == ConsoleState.DISCONNECTED:
+            return False
+        return self.pty.isalive()
+
     def connect(self):
         self.state = ConsoleState.CONNECTED
 
@@ -438,6 +443,11 @@ class CmdConsole(Console):
     def __init__(self, cmd, log=None):
         super().__init__(log)
         self.cmd = cmd
+
+    def is_connected(self):
+        if self.state == ConsoleState.DISCONNECTED:
+            return False
+        return self.pty.isalive()
 
     def connect(self):
         if self.pty:
@@ -469,6 +479,11 @@ class SSHConsole(Console):
         self.delaybeforesend = delaybeforesend
 
         super().__init__(log, prompt)
+
+    def is_connected(self):
+        if self.state == ConsoleState.DISCONNECTED:
+            return False
+        return self.pty.isalive()
 
     def close(self):
         if self.state == ConsoleState.DISCONNECTED:

--- a/src/optest/console.py
+++ b/src/optest/console.py
@@ -178,7 +178,7 @@ class Console():
         # /bin/sh) barfs if you pass it any arguments.
         # Execing into sh with ENV set to /dev/null stops it from running
         # the rc file so do that instead.
-        self.pty.sendline("ENV=/dev/null which sh && exec sh")
+        self.pty.sendline("ENV=\"/dev/null\" which sh && exec sh;")
 
         # NB: If you change the tty dimensions from (300, 30) to something else
         # make sure the screen sized assumed by PetitbootHelper is kept in sync.

--- a/src/optest/exceptions.py
+++ b/src/optest/exceptions.py
@@ -54,6 +54,9 @@ class PowerOnError(OpTestError):
 class PowerOffError(OpTestError):
     pass
 
+class PowerOffTimeout(OpTestError):
+    pass
+
 class CommandFailed(Exception):
     '''
     Running a command (BMC or Host) failed with non-zero exit code.

--- a/src/optest/ipmi.py
+++ b/src/optest/ipmi.py
@@ -205,6 +205,11 @@ class IPMIConsole(Console):
             self.state = ConsoleState.DISCONNECTED
             pass
 
+    def is_connected(self):
+        if self.state == ConsoleState.DISCONNECTED:
+            return False
+        return self.pty.isalive()
+
     def connect(self, logger=None):
         if self.state == ConsoleState.CONNECTED:
             raise 're-opening connected console'  # FIXME: handle properly

--- a/src/optest/ipmi.py
+++ b/src/optest/ipmi.py
@@ -46,7 +46,7 @@ import re
 from .constants import Constants as BMC_CONST
 #from .OpTestUtil import OpTestUtil
 #from . import OpTestSystem
-from .exceptions import CommandFailed, BMCDisconnected, OpTestError
+from .exceptions import CommandFailed, BMCDisconnected, OpTestError, ParameterCheck
 from . import opexpect
 from .console import Console, ConsoleState
 
@@ -76,8 +76,11 @@ class IPMITool():
         s = ' -H %s -I %s' % (self.ip, self.method)
         if self.username:
             s += ' -U %s' % (self.username)
-        if self.password:
-            s += ' -P %s' % (self.password)
+
+        if not self.password:
+            raise ParameterCheck(message="An IPMI password is required")
+
+        s += ' -P %s' % (self.password)
         s += ' '
         return s
 

--- a/src/optest/openpower.py
+++ b/src/optest/openpower.py
@@ -88,6 +88,25 @@ class OsState(SysState):
     def run(self, system, stop):
         system.get_console().shell_setup()
 
+    def check(self, system):
+        # When checking whether we're at an OS we don't want to make too many
+        # assumptions about *what* OS we're in. Checking /etc/os-release might isn't
+        # ideal since although we use buildroot for petitboot I want
+        # the ability to use a BR system as a test environment.
+
+        # Can we run a command? If not, probably not at the OS.
+        try:
+            result = system.run_command("ps | grep pb-discover | wc -l")
+        except:
+            return False
+
+        # Is pb-discover running? If so, probably petitboot.
+        if int(result[0]) >= 2: # we'll always count the grep process
+            return False
+
+        # FIXME: We should probably check a little harder.
+        return True
+
 class OpSystem(BaseSystem):
     openpower_state_table = [
         # NB: we're ignoring the SBE since some systems don't have SBE output

--- a/src/optest/openpower.py
+++ b/src/optest/openpower.py
@@ -96,7 +96,10 @@ class OsState(SysState):
 
         # Can we run a command? If not, probably not at the OS.
         try:
-            result = system.run_command("ps | grep pb-discover | wc -l")
+            # Busybox ps just prints everything and sometimes it chokes on
+            # having arguments to ps (e.g. -ef or aux). We just want to reject
+            # petitboot so using a bare "ps" should be fine.
+            result, rc = system.run_command("ps | grep pb-discover | wc -l")
         except:
             return False
 

--- a/src/optest/petitboot.py
+++ b/src/optest/petitboot.py
@@ -397,3 +397,11 @@ class PetitbootState(ConsoleState):
 
         # otherwise just wait for the autoboot to happen
         self._watch_for(system, self.pb_exit, self.exit_timeout)
+
+    def check(self, system):
+        # the validation that PetitbootHelper does should be enough
+        try:
+            pb = PetitbootHelper(system)
+        except:
+            return False
+        return True

--- a/src/optest/qemu.py
+++ b/src/optest/qemu.py
@@ -78,7 +78,9 @@ class QemuConsole(Console):
         # FIXME: do we need to call super().close()?
 
     def is_connected(self):
-        return self.state == ConsoleState.CONNECTED
+        if self.state == ConsoleState.DISCONNECTED:
+            return False
+        return self.pty.isalive()
 
 qemu_state_table = [
     SysConsoleState('skiboot', openpower.skiboot_entry, 10, openpower.skiboot_exit, 30),

--- a/src/optest/system.py
+++ b/src/optest/system.py
@@ -244,8 +244,16 @@ class BaseSystem(object):
         # possibly excessive, but we've found some systems where it can take
         # a while for the BMC to work again due to NC-SI issues.
         if softoff:
-            log.info("Soft powering off host...")
-            self.host_power_off()
+            for i in range(5):
+                log.info("Soft powering off host... Attempt {} / 5".format(i))
+                try:
+                    self.host_power_off()
+                except:
+                    time.sleep(1)
+                    continue
+
+                break
+
             try:
                 self.poweroff_wait()
                 log.info("Soft power off finished")


### PR DESCRIPTION
-> Make the shell / menu detection in PetitbootHelper more robust.
-> Rework how system::poweroff() works so we're always logging what's going on.
-> Some other misc fixes

edit: Oh yeah I added some support for checking if a system is in a given state. We can use this to skip reboots similar to how the old goto_state() logic worked.