### PR TITLE
Fix directory structure as per new qemu build changes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,7 +2,7 @@
 
 # there's a lot of distros where packaged qemu eithe don't support the powernv
 # or only supports an old one, so build our own
-if ! [ -f qemu/ppc64-softmmu/qemu-system-ppc64 ] ; then
+if ! [ -f qemu/build/qemu-system-ppc64 ] ; then
 	ci/build-qemu-powernv.sh
 fi
 
@@ -15,7 +15,7 @@ if ! [ -f ./qemu.conf ] ; then
 	cat - > qemu.conf <<EOF
 [op-test]
 bmc_type=qemu
-qemu_binary=qemu/ppc64-softmmu/qemu-system-ppc64
+qemu_binary=qemu/build/qemu-system-ppc64
 flash_skiboot=skiboot.lid
 flash_kernel=vmlinux
 flash_initramfs=initramfs

--- a/ci/build-qemu-powernv.sh
+++ b/ci/build-qemu-powernv.sh
@@ -3,7 +3,7 @@ set -e
 set -vx
 
 # Check if we already have a qemu binary. Nothing to be done otherwise.
-if [ -f "qemu/ppc64-softmmu/qemu-system-ppc64" ] ; then
+if [ -f "qemu/build/qemu-system-ppc64" ] ; then
 	exit 0;
 fi
 
@@ -17,11 +17,13 @@ branch="master"
 head_sha="$(git ls-remote --heads $repo $branch | cut -f 1)"
 cachedir="ci_cache/qemu/$head_sha/"
 
-if [ -f "$cachedir/qemu-system-ppc64" ] ; then
-	mkdir -p qemu/ppc64-softmmu/
-	cp $cachedir/qemu-system-ppc64 qemu/ppc64-softmmu/
-	exit 0
-fi
+#FixMe : This has to be fixed so the qemu compilation time 
+#        can be reduced on CI. 
+#if [ -f "$cachedir/qemu-system-ppc64" ] ; then
+#	mkdir -p qemu/build/
+#	cp -p $cachedir/qemu-system-ppc64 ./qemu/build/.
+#	exit 0
+#fi
 
 # zap any existing cached builds
 rm -rf ci_build_cache/qemu/
@@ -31,10 +33,10 @@ git clone --depth=1 -b $branch $repo
 
 cd qemu
 git submodule update --init dtc
-./configure --target-list=ppc64-softmmu --disable-werror --python=/usr/bin/python3
+./configure --target-list=ppc64-softmmu --disable-werror 
 make -j $(grep -c processor /proc/cpuinfo)
 
 # prep the cache
 cd ..
 mkdir -p $cachedir
-cp qemu/ppc64-softmmu/qemu-system-ppc64 $cachedir/qemu-system-ppc64
+cp -p qemu/build/qemu-system-ppc64 $cachedir/qemu-system-ppc64

--- a/selftests/test_configs/qemu.conf.example
+++ b/selftests/test_configs/qemu.conf.example
@@ -1,6 +1,6 @@
 [op-test]
 bmc_type=qemu
-qemu_binary=../qemu/ppc64-softmmu/qemu-system-ppc64
+qemu_binary=../qemu/build/qemu-system-ppc64
 flash_skiboot=test_data/skiboot.lid
 flash_kernel=test_data/vmlinux
 flash_initramfs=test_data/initramfs

--- a/src/optest/opexpect.py
+++ b/src/optest/opexpect.py
@@ -85,7 +85,8 @@ def handle_opal_err(pty, is_assert):
 
     # hmm,  might need to move this elsewhere
     l = super(spawn, pty).expect(["boot_entry.*\r\n",
-                                   "Initiated MPIPL", pexpect.TIMEOUT],
+                                   "Initiated MPIPL",
+                                   "NVRAM: Failed to load", pexpect.TIMEOUT],
                                    timeout=10)
     log = log + pty.before + pty.after
     if is_assert:


### PR DESCRIPTION
Latest qemu builds all binary into build folder.
Nomore ppc64_softmmu, hence fixed the same.

Signed-off-by: Hariharan T.S <harihare@in.ibm.com>